### PR TITLE
Add Docker Compose deployment with persistent storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Rust build artifacts
+target/
+**/target/
+
+# Node.js dependencies and build output
+node_modules/
+**/node_modules/
+.next/
+out/
+frontend/.next/
+frontend/out/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Docker files (avoid recursive copies)
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Test outputs
+tests/output/
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# CI/CD
+.github/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ name = "oxdraw"
 version = "0.2.0"
 edition = "2024"
 include = [
-	"Cargo.toml",
-	"build.rs",
-	"README.md",
-	"src/**",
-	"tests/**",
-	"frontend/out/**",
+    "Cargo.toml",
+    "build.rs",
+    "README.md",
+    "src/**",
+    "tests/**",
+    "frontend/out/**",
 ]
 authors = ["Rohan Adwankar <rohan.adwankar@gmail.com>"]
 description = "Library, CLI and Web View for Declarative Diagramming"
@@ -36,21 +36,26 @@ serde_json = "1.0"
 thiserror = "1.0"
 walkdir = "2.4"
 directories = "5.0"
-
-tokio = { version = "1", features = [
-	"macros",
-	"rt-multi-thread",
-	"signal",
-	"sync",
-	"fs",
-], optional = true }
-tower-http = { version = "0.5", features = ["cors", "fs"], optional = true }
-tower = { version = "0.5", optional = true }
-resvg = { version = "0.43", features = ["text"] }
-tiny-skia = { version = "0.11", features = ["png"], default-features = false }
+uuid = { version = "1", features = ["v4"] }
+sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio"] }
+chrono = { version = "0.4", features = ["serde"] }
+zip = { version = "2", default-features = false }
 base64 = "0.22"
 reqwest = { version = "0.11", features = ["json"] }
 regex = "1.12.2"
+time = { version = "0.3", features = ["macros"] }
+cookie = "0.18"
+tiny-skia = { version = "0.11", optional = true }
+tokio = { version = "1", features = [
+    "macros",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "fs",
+], optional = true }
+tower-http = { version = "0.5", features = ["cors", "fs"], optional = true }
+tower = { version = "0.5", optional = true }
+http-body-util = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 assert_cmd = "2.1.1"
@@ -60,7 +65,7 @@ wasm-bindgen-test = "0.3"
 
 [features]
 default = ["server"]
-server = ["axum", "tokio", "tower-http", "tower"]
+server = ["axum", "tokio", "tower-http", "tower", "tiny-skia"]
 
 [profile.release]
 codegen-units = 1

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,98 @@
+# Frontend build stage
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+# Copy frontend package files
+COPY frontend/package.json frontend/package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy frontend source
+COPY frontend/ ./
+
+# Build frontend (static export to out/)
+RUN npm run build
+
+# Rust build stage - using nightly for Edition 2024 support
+FROM rustlang/rust:nightly-bookworm AS builder
+
+# Install sqlite3 for SQLx query validation
+RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create a dummy main.rs to build dependencies
+RUN mkdir -p src && echo "fn main() {}" > src/main.rs && echo "pub fn dummy() {}" > src/lib.rs
+
+# Create dummy frontend/out to satisfy build.rs during dependency build
+RUN mkdir -p frontend/out && touch frontend/out/index.html
+
+# Create the database directory and initialize the database
+RUN mkdir -p /data && touch /data/oxdraw.db && \
+    sqlite3 /data/oxdraw.db "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')), last_activity_at TEXT NOT NULL DEFAULT (datetime('now')));" && \
+    sqlite3 /data/oxdraw.db "CREATE TABLE IF NOT EXISTS diagrams (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, name TEXT NOT NULL, filename TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), is_deleted INTEGER NOT NULL DEFAULT 0);" && \
+    sqlite3 /data/oxdraw.db "CREATE INDEX IF NOT EXISTS idx_diagrams_session ON diagrams(session_id, updated_at DESC);" && \
+    sqlite3 /data/oxdraw.db "CREATE INDEX IF NOT EXISTS idx_diagrams_expire ON diagrams(updated_at);"
+
+# Set DATABASE_URL for SQLx compile-time validation
+ENV DATABASE_URL="sqlite:data/oxdraw.db"
+
+# Build dependencies only (this layer will be cached)
+RUN cargo build --release && rm -rf src
+
+# Copy actual source code
+COPY src ./src
+COPY build.rs ./build.rs
+
+# Copy the built frontend from frontend-builder stage
+COPY --from=frontend-builder /app/frontend/out ./frontend/out
+
+# Touch main.rs to invalidate the cache for the actual build
+RUN touch src/main.rs
+
+# Build the actual application
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    libfontconfig1 \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create data directory for SQLite database
+RUN mkdir -p /data
+
+# Create data directory for SQLite database
+RUN mkdir -p /app/data
+
+# Copy the built binary
+COPY --from=builder /app/target/release/oxdraw /usr/local/bin/oxdraw
+
+# Copy the pre-built database template
+COPY --from=builder /data/oxdraw.db /app/data/oxdraw.db.template
+
+# Set the database path
+ENV OXDRAW_DB_PATH=/data/oxdraw.db
+
+# Create a startup script that initializes the database if needed
+RUN echo '#!/bin/bash\n\
+# If database does not exist, copy the template\n\
+if [ ! -f /data/oxdraw.db ]; then\n\
+    cp /app/data/oxdraw.db.template /data/oxdraw.db\n\
+fi\n\
+exec /usr/local/bin/oxdraw "$@"' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Default command (can be overridden)
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -23,25 +23,64 @@ The reason I started this project was I used Mermaid a lot in the past when maki
 
 ## Usage
 
-### Install fom Cargo
+### Web Editor (Recommended)
+
+The easiest way to use oxdraw is via the web editor, which offers a privacy-first, multi-user experience:
+
+```bash
+# Build and start all services with Docker Compose
+docker compose up --build
+
+# Run in detached mode
+docker compose up -d --build
+
+# Stop services
+docker compose down
+```
+
+Once running:
+- **Web UI**: http://localhost:3000
+- **Backend API**: http://localhost:5151
+
+#### Web Editor Features
+
+| Feature | Description |
+|---------|-------------|
+| **Zero-Knowledge** | No personal data stored. Files expire after 7 days. |
+| **Multiple Files** | Create and manage up to 10 diagrams per session |
+| **Templates** | Start with Flowchart, Sequence, Class, State, or ER diagrams |
+| **Export** | Download individual .mmd files or export all as ZIP |
+| **Auto-Save** | Changes are saved automatically |
+| **Privacy Notice** | First-visit consent for privacy transparency |
+
+#### Environment Variables (Docker)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OXDRAW_MAX_FILES` | 10 | Maximum files per session |
+| `OXDRAW_EXPIRATION_DAYS` | 7 | Days before files are deleted |
+
+### CLI Usage
+
+#### Install from Cargo
 
 ```bash
 cargo install oxdraw
 ```
 
-### Render a Diagram from a File
+#### Render a Diagram from a File
 
 ```bash
 oxdraw --input flow.mmd  
 ```
 
-### Launch the Interactive Editor
+#### Launch the Interactive Editor
 
 ```bash
 oxdraw --input flow.mmd --edit
 ```
 
-### Have AI Generate a Codemap
+#### Have AI Generate a Codemap
 This will also launch the interactive viewer mapping the nodes to files in the repo. You can refer to [ai.md](docs/ai.md) for free resources on setting up AI access
 
 ```bash
@@ -73,6 +112,33 @@ oxdraw --code-map ./src/diagram.rs --no-ai --output test.png
 | `--regen` | Force regeneration of the code map even if a cache exists. |
 | `--prompt <PROMPT>` | Custom prompt to append to the LLM instructions. |
 
+### Web Editor Features
+
+The web editor provides a privacy-first experience for creating and managing diagrams:
+
+| Feature | Description |
+|---------|-------------|
+| **Zero-Knowledge Storage** | No personal data, IP addresses, or user agents are stored. Only session IDs in cookies. |
+| **Auto-Expiration** | Files are automatically deleted 7 days after last edit. |
+| **Multiple Diagrams** | Create and manage up to 10 diagrams per browser session |
+| **Templates** | Start quickly with Flowchart, Sequence, Class, State, or ER diagram templates |
+| **Export Options** | Download individual `.mmd` files or export all diagrams as a ZIP archive |
+| **Privacy Consent** | First-visit modal explaining privacy policy and data handling |
+| **Cookie-Based Sessions** | 30-day session persistence with no registration required |
+
+#### Web Editor API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/session` | GET | Get or create session (auto-creates cookie) |
+| `/api/files` | GET | List all files for current session |
+| `/api/files` | POST | Create new file with optional template |
+| `/api/files/:id` | GET/PUT/DELETE | Read, update, or delete a file |
+| `/api/files/:id/duplicate` | POST | Duplicate a file |
+| `/api/files/:id/download` | GET | Download single `.mmd` file |
+| `/api/files/export` | GET | Download all files as ZIP |
+| `/api/files/:id/diagram` | GET | Get parsed diagram data |
+
 ### Frontend Features
 
 | Control | What it does |
@@ -103,6 +169,32 @@ Some prefer smooth lines because there is less total line but I prefer strong ed
 Some prefer no overlapping lines but I sometimes prefer an overlap rather than letting the lines get super long and string out of the diagram very far.
 This is an example of using the delete key to remove one relationship and then using the arrow keys to move around one the nodes and seeing how the algorithm recomputes the positioning.
 There's definitely some improvements to be made to this algorithm so I imagine this will keep getting better :)
+
+## Privacy & Data Retention
+
+The oxdraw web editor is designed with privacy as a core principle:
+
+### What We Store
+- **Session ID**: A random UUID stored in an HttpOnly cookie (30-day expiration)
+- **Diagram Content**: Your Mermaid source code and visual overrides (7-day TTL)
+- **Timestamps**: Created/updated times for expiration logic
+
+### What We Don't Store
+- IP addresses
+- User agents or browser fingerprints
+- Email addresses or personal information
+- Access logs or analytics
+
+### Data Lifecycle
+1. **Creation**: New sessions and files are created with timestamps
+2. **Activity**: Session last-active timestamp updates on each request
+3. **Expiration**: Files are deleted 7 days after last edit
+4. **Cleanup**: Orphaned sessions (no files) are deleted after 7 days of inactivity
+
+### User Responsibilities
+- **Export Your Data**: Use the ZIP export feature to backup your diagrams
+- **Clear Cookies**: Clearing browser cookies will delete all associated data
+- **No Recovery**: There are no backups. Once deleted, data cannot be recovered.
 
 ## Community
 If you do end up using oxdraw, please let me know! You can open issues or discussion posts on GitHub or reach out to me on one of the socials from my Github profile. I would love to hear how you are using it, any feedback you have, and/or add your project to this section!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+## PORTS
+##    expose backend outside docker stack
+#    ports:
+#      - "5151:5151"
+##   DEFAULT
+#   expose port only WITHIN docker stack 
+    expose:
+      - "5151"
+    environment:
+      - RUST_LOG=info
+      - OXDRAW_MAX_FILES=10
+      - OXDRAW_EXPIRATION_DAYS=7
+      - OXDRAW_DB_PATH=/data/oxdraw.db
+    volumes:
+      - oxdraw_data:/data
+    command: ["serve", "--host", "0.0.0.0"]
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  oxdraw_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,40 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.*
+.yarn/*
+
+# Build output
+.next/
+out/
+build/
+
+# Testing
+coverage/
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Environment files
+.env*
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Git
+.git/
+.gitignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,50 @@
+# Build stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the Next.js application (static export)
+RUN npm run build
+
+# Runtime stage - serve static files with nginx
+FROM nginx:alpine
+
+# Copy built static files to nginx
+COPY --from=builder /app/out /usr/share/nginx/html
+
+# Copy custom nginx config for SPA routing with API proxy
+RUN cat > /etc/nginx/conf.d/default.conf << 'EOF'
+server {
+    listen 3000;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:5151;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+}
+EOF
+
+# Expose port
+EXPOSE 3000
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -904,3 +904,32 @@ body > div:first-of-type {
   background: var(--bg-tertiary);
   font-weight: 600;
 }
+
+.diagram-selector {
+  position: relative;
+}
+
+.diagram-selector button {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diagram-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px var(--shadow-color);
+  z-index: 1000;
+  min-width: 200px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.diagram-dropdown > div:hover {
+  background: var(--bg-tertiary);
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -79,6 +79,9 @@ export interface SubgraphData {
 }
 
 export interface DiagramData {
+  id: number;
+  name: string;
+  filename: string;
   sourcePath: string;
   background: string;
   autoSize: Size;
@@ -87,6 +90,14 @@ export interface DiagramData {
   edges: EdgeData[];
   subgraphs?: SubgraphData[];
   source: string;
+}
+
+export interface DiagramSummary {
+  id: number;
+  name: string;
+  filename: string;
+  updatedAt: string;
+  expiresAt: string;
 }
 
 export interface LayoutUpdate {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,7 +329,7 @@ async fn run_edit(cli: RenderArgs) -> Result<()> {
     let port = cli.serve_port.unwrap_or(5151);
 
     let serve_args = ServeArgs {
-        input: canonical_input.clone(),
+        input: Some(canonical_input.clone()),
         host: host.clone(),
         port,
         background_color: cli.background_color.clone(),
@@ -517,7 +517,7 @@ async fn run_code_map(cli: RenderArgs, code_map_path: String) -> Result<()> {
         let port = cli.serve_port.unwrap_or(5151);
 
         let serve_args = ServeArgs {
-            input: path.canonicalize()?,
+            input: Some(path.canonicalize()?),
             host: host.clone(),
             port,
             background_color: cli.background_color,
@@ -602,7 +602,7 @@ async fn run_code_map(cli: RenderArgs, code_map_path: String) -> Result<()> {
                 if cli.scale <= 0.0 {
                     bail!("--scale must be greater than zero for PNG output");
                 }
-                diagram.render_png(&cli.background_color, None, cli.scale)?
+                diagram.render_png(Some(&cli.background_color), None, cli.scale)?
             } else {
                 diagram.render_svg(&cli.background_color, None)?.into_bytes()
             };
@@ -628,7 +628,7 @@ async fn run_code_map(cli: RenderArgs, code_map_path: String) -> Result<()> {
     let port = cli.serve_port.unwrap_or(5151);
 
     let serve_args = ServeArgs {
-        input: diagram_path,
+        input: Some(diagram_path),
         host: host.clone(),
         port,
         background_color: cli.background_color,
@@ -683,7 +683,7 @@ fn run_render(cli: RenderArgs) -> Result<()> {
         OutputFormat::Svg => diagram
             .render_svg(&cli.background_color, override_ref)?
             .into_bytes(),
-        OutputFormat::Png => diagram.render_png(&cli.background_color, override_ref, cli.scale)?,
+        OutputFormat::Png => diagram.render_png(Some(&cli.background_color), override_ref, cli.scale)?,
     };
 
     write_output(output_dest, &output_bytes, cli.quiet)?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,161 @@
+use sqlx::{sqlite::SqlitePool, Pool, Sqlite};
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+const MAX_FILES_DEFAULT: usize = 10;
+const EXPIRATION_DAYS_DEFAULT: i64 = 7;
+
+#[derive(Debug, Clone)]
+pub struct DatabaseConfig {
+    pub path: PathBuf,
+    pub max_files_per_session: usize,
+    pub expiration_days: i64,
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from(
+                std::env::var("OXDRAW_DB_PATH")
+                    .unwrap_or_else(|_| "oxdraw.db".to_string())
+            ),
+            max_files_per_session: std::env::var("OXDRAW_MAX_FILES")
+                .unwrap_or_else(|_| "10".to_string())
+                .parse()
+                .unwrap_or(MAX_FILES_DEFAULT),
+            expiration_days: std::env::var("OXDRAW_EXPIRATION_DAYS")
+                .unwrap_or_else(|_| "7".to_string())
+                .parse()
+                .unwrap_or(EXPIRATION_DAYS_DEFAULT),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Database {
+    pool: Pool<Sqlite>,
+    config: DatabaseConfig,
+}
+
+impl Database {
+    pub async fn new(config: DatabaseConfig) -> Result<Self> {
+        let db_url = if config.path.is_absolute() {
+            format!("sqlite:///{}", config.path.display())
+        } else {
+            format!("sqlite:{}", config.path.display())
+        };
+        let pool = SqlitePool::connect(&db_url)
+            .await
+            .context("Failed to connect to SQLite database")?;
+
+        let db = Self {
+            pool,
+            config: config.clone(),
+        };
+
+        db.run_migrations().await?;
+        Ok(db)
+    }
+
+    pub fn pool(&self) -> &Pool<Sqlite> {
+        &self.pool
+    }
+
+    pub fn config(&self) -> &DatabaseConfig {
+        &self.config
+    }
+
+    async fn run_migrations(&self) -> Result<()> {
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        "#)
+        .execute(&self.pool)
+        .await
+        .context("Failed to create sessions table")?;
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS diagrams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            )
+        "#)
+        .execute(&self.pool)
+        .await
+        .context("Failed to create diagrams table")?;
+
+        sqlx::query(r#"CREATE INDEX IF NOT EXISTS idx_diagrams_session ON diagrams(session_id, updated_at DESC)"#)
+        .execute(&self.pool)
+        .await
+        .context("Failed to create diagrams_session index")?;
+
+        sqlx::query(r#"CREATE INDEX IF NOT EXISTS idx_diagrams_expire ON diagrams(updated_at)"#)
+        .execute(&self.pool)
+        .await
+        .context("Failed to create diagrams_expire index")?;
+
+        Ok(())
+    }
+
+    pub async fn cleanup_expired(&self) -> Result<(u64, u64)> {
+        let expiration_days = self.config.expiration_days;
+
+        let diagrams_deleted = sqlx::query(
+            r#"DELETE FROM diagrams WHERE updated_at < datetime('now', ?)"#,
+        )
+        .bind(format!("-{} days", expiration_days))
+        .execute(&self.pool)
+        .await
+        .context("Failed to cleanup expired diagrams")?
+        .rows_affected();
+
+        let sessions_deleted = sqlx::query(
+            r#"DELETE FROM sessions WHERE id NOT IN (SELECT DISTINCT session_id FROM diagrams)
+               AND last_activity_at < datetime('now', ?)"#,
+        )
+        .bind(format!("-{} days", expiration_days))
+        .execute(&self.pool)
+        .await
+        .context("Failed to cleanup orphaned sessions")?
+        .rows_affected();
+
+        Ok((diagrams_deleted, sessions_deleted))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_database_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let config = DatabaseConfig {
+            path: db_path,
+            max_files_per_session: 10,
+            expiration_days: 7,
+        };
+
+        let db = Database::new(config).await.unwrap();
+        let _: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM sessions")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let _: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM diagrams")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,121 @@
+use sqlx::SqlitePool;
+use anyhow::{Result, Context};
+use std::io::{Cursor, Write};
+use zip::write::{FileOptions, ZipWriter};
+
+#[derive(sqlx::FromRow)]
+struct FileRow {
+    name: String,
+    filename: String,
+    content: String,
+}
+
+pub async fn export_all_files(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> Result<Vec<u8>> {
+    let files: Vec<FileRow> = sqlx::query_as(
+        "SELECT name, filename, content FROM diagrams
+         WHERE session_id = ? AND is_deleted = 0
+         ORDER BY updated_at DESC",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await
+    .context("Failed to fetch files for export")?;
+
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut cursor = Cursor::new(Vec::new());
+    let mut zip = ZipWriter::new(&mut cursor);
+    let options: FileOptions<()> = FileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .unix_permissions(0o644);
+
+    for file in &files {
+        let filename = if file.filename.is_empty() {
+            format!("{}.mmd", file.name)
+        } else {
+            file.filename.clone()
+        };
+
+        zip.start_file(filename, options)
+            .with_context(|| "Failed to start zip file entry".to_string())?;
+        zip.write_all(file.content.as_bytes())
+            .with_context(|| "Failed to write file content".to_string())?;
+    }
+
+    zip.finish()
+        .with_context(|| "Failed to finalize ZIP file".to_string())?;
+
+    Ok(cursor.into_inner())
+}
+
+pub fn export_single_file(_filename: &str, content: &str) -> Result<Vec<u8>> {
+    Ok(content.as_bytes().to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use sqlx::SqlitePool;
+    use crate::session::Session;
+    use crate::files::DiagramFile;
+
+    async fn setup_test_db() -> (SqlitePool, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let pool = SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+            .await
+            .unwrap();
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        "#).execute(&pool).await.unwrap();
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS diagrams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            )
+        "#).execute(&pool).await.unwrap();
+
+        let session = Session::create(&pool).await.unwrap();
+        (pool, session.id)
+    }
+
+    #[tokio::test]
+    async fn test_single_export() {
+        let content = "graph TD\nA --> B";
+        let result = export_single_file("test.mmd", content).unwrap();
+        assert_eq!(result, content.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_bulk_export() {
+        let (pool, session_id) = setup_test_db().await;
+
+        DiagramFile::create(&pool, &session_id, "file1.mmd", Some("flowchart")).await.unwrap();
+        DiagramFile::create(&pool, &session_id, "file2.mmd", Some("sequence")).await.unwrap();
+
+        let zip_data = export_all_files(&pool, &session_id).await.unwrap();
+        assert!(!zip_data.is_empty());
+
+        let mut zip = zip::ZipArchive::new(Cursor::new(zip_data)).unwrap();
+        assert_eq!(zip.len(), 2);
+    }
+}

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,0 +1,380 @@
+use sqlx::SqlitePool;
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiagramFile {
+    pub id: i64,
+    pub session_id: String,
+    pub name: String,
+    pub filename: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileListItem {
+    pub id: i64,
+    pub name: String,
+    pub filename: String,
+    pub updated_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionInfo {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub last_activity_at: DateTime<Utc>,
+    pub file_count: i64,
+    pub max_files: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileResponse {
+    pub file: DiagramFile,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileListResponse {
+    pub files: Vec<FileListItem>,
+    pub max_files: usize,
+    pub current_file_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateFileRequest {
+    pub name: String,
+    pub template: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateFileRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateFileRequest {
+    pub name: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct FileListRow {
+    id: i64,
+    name: String,
+    filename: String,
+    updated_at: String,
+}
+
+pub fn get_template(template: &str) -> &'static str {
+    match template {
+        "flowchart" | "graph" => "graph TD\n    Start([Start]) --> Process[Process]\n    Process --> End([End])",
+        "sequence" => "sequenceDiagram\n    participant A as Alice\n    participant B as Bob\n    A->>B: Hello\n    B->>A: Hi!",
+        "class" => "classDiagram\n    Animal <|-- Duck\n    Animal <|-- Fish\n    Animal : +int age\n    Animal : +String gender",
+        "state" => "stateDiagram-v2\n    [*] --> Active\n    Active --> Inactive\n    Inactive --> Active",
+        "er" => "erDiagram\n    CUSTOMER ||--o{ ORDER : places\n    CUSTOMER ||--|{ DELIVERY-ADDRESS : has",
+        "journey" => "journey\n    My day\n    I wake up, 5, \"Happy\"\n    I eat breakfast, 5, \"Hungry\"\n    I go to work, 2, \"Sad\"",
+        _ => "graph TD\n    A[Start] --> B[Process]\n    B --> C[End]",
+    }
+}
+
+impl DiagramFile {
+    pub async fn create(
+        pool: &SqlitePool,
+        session_id: &str,
+        name: &str,
+        template: Option<&str>,
+    ) -> Result<Self> {
+        let filename = if name.ends_with(".mmd") {
+            name.to_string()
+        } else {
+            format!("{}.mmd", name)
+        };
+
+        let content = match template {
+            Some(t) => get_template(t).to_string(),
+            None => get_template("flowchart").to_string(),
+        };
+
+        let now = Utc::now();
+        let id = sqlx::query(
+            r#"INSERT INTO diagrams (session_id, name, filename, content, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(session_id)
+        .bind(name)
+        .bind(&filename)
+        .bind(&content)
+        .bind(now.to_rfc3339())
+        .bind(now.to_rfc3339())
+        .execute(pool)
+        .await
+        .context("Failed to create diagram")?
+        .last_insert_rowid();
+
+        Ok(Self {
+            id,
+            session_id: session_id.to_string(),
+            name: name.to_string(),
+            filename,
+            content,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    pub async fn get_by_id(pool: &SqlitePool, id: i64, session_id: &str) -> Result<Option<Self>> {
+        let row: Option<DiagramFileRow> = sqlx::query_as(
+            "SELECT id, session_id, name, filename, content, created_at, updated_at
+             FROM diagrams WHERE id = ? AND session_id = ? AND is_deleted = 0",
+        )
+        .bind(id)
+        .bind(session_id)
+        .fetch_optional(pool)
+        .await
+        .context("Failed to get diagram")?;
+
+        Ok(row.map(|r| Self {
+            id: r.id,
+            session_id: r.session_id,
+            name: r.name,
+            filename: r.filename,
+            content: r.content,
+            created_at: r.created_at.parse().unwrap_or_else(|_| Utc::now()),
+            updated_at: r.updated_at.parse().unwrap_or_else(|_| Utc::now()),
+        }))
+    }
+
+    pub async fn list_by_session(
+        pool: &SqlitePool,
+        session_id: &str,
+    ) -> Result<Vec<FileListItem>> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            id: i64,
+            name: String,
+            filename: String,
+            updated_at: String,
+        }
+
+        let rows: Vec<Row> = sqlx::query_as(
+            "SELECT id, name, filename, updated_at FROM diagrams
+             WHERE session_id = ? AND is_deleted = 0
+             ORDER BY updated_at DESC",
+        )
+        .bind(session_id)
+        .fetch_all(pool)
+        .await
+        .context("Failed to list diagrams")?;
+
+        let expiration_days = 7;
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let updated_at: DateTime<Utc> = r.updated_at.parse().unwrap_or_else(|_| Utc::now());
+                let expires_at = updated_at + chrono::Duration::days(expiration_days);
+                FileListItem {
+                    id: r.id,
+                    name: r.name,
+                    filename: r.filename,
+                    updated_at,
+                    expires_at,
+                }
+            })
+            .collect())
+    }
+
+    pub async fn update_content(&self, pool: &SqlitePool, content: &str) -> Result<Self> {
+        let now = Utc::now();
+        sqlx::query(
+            "UPDATE diagrams SET content = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(content)
+        .bind(now.to_rfc3339())
+        .bind(self.id)
+        .execute(pool)
+        .await
+        .context("Failed to update diagram")?;
+
+        Ok(Self {
+            content: content.to_string(),
+            updated_at: now,
+            ..self.clone()
+        })
+    }
+
+    pub async fn delete(&self, pool: &SqlitePool) -> Result<()> {
+        sqlx::query(
+            "UPDATE diagrams SET is_deleted = 1 WHERE id = ?",
+        )
+        .bind(self.id)
+        .execute(pool)
+        .await
+        .context("Failed to delete diagram")?;
+        Ok(())
+    }
+
+    pub async fn duplicate(&self, pool: &SqlitePool, new_name: Option<&str>) -> Result<Self> {
+        let name = match new_name {
+            Some(n) => n.to_string(),
+            None => format!("{} (copy)", self.name),
+        };
+        let filename = if name.ends_with(".mmd") {
+            name.clone()
+        } else {
+            format!("{}.mmd", name)
+        };
+
+        let now = Utc::now();
+        let id = sqlx::query(
+            r#"INSERT INTO diagrams (session_id, name, filename, content, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&self.session_id)
+        .bind(&name)
+        .bind(&filename)
+        .bind(&self.content)
+        .bind(now.to_rfc3339())
+        .bind(now.to_rfc3339())
+        .execute(pool)
+        .await
+        .context("Failed to duplicate diagram")?
+        .last_insert_rowid();
+
+        Ok(Self {
+            id,
+            session_id: self.session_id.clone(),
+            name: name.clone(),
+            filename,
+            content: self.content.clone(),
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    pub async fn count_by_session(pool: &SqlitePool, session_id: &str) -> Result<i64> {
+        let count = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM diagrams WHERE session_id = ? AND is_deleted = 0",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .context("Failed to count diagrams")?;
+        Ok(count)
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct DiagramFileRow {
+    id: i64,
+    session_id: String,
+    name: String,
+    filename: String,
+    content: String,
+    created_at: String,
+    updated_at: String,
+}
+
+pub async fn get_session_info(
+    pool: &SqlitePool,
+    session_id: &str,
+    max_files: usize,
+) -> Result<SessionInfo> {
+    let session: Option<SessionRow> = sqlx::query_as(
+        "SELECT id, created_at, last_activity_at FROM sessions WHERE id = ?",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await
+    .context("Failed to get session")?;
+
+    let file_count = DiagramFile::count_by_session(pool, session_id).await?;
+
+    if let Some(s) = session {
+        Ok(SessionInfo {
+            id: s.id,
+            created_at: s.created_at.parse().unwrap_or_else(|_| Utc::now()),
+            last_activity_at: s.last_activity_at.parse().unwrap_or_else(|_| Utc::now()),
+            file_count,
+            max_files,
+        })
+    } else {
+        bail!("Session not found")
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct SessionRow {
+    id: String,
+    created_at: String,
+    last_activity_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use sqlx::SqlitePool;
+
+    async fn setup_test_db() -> (SqlitePool, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let pool = SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+            .await
+            .unwrap();
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        "#).execute(&pool).await.unwrap();
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS diagrams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            )
+        "#).execute(&pool).await.unwrap();
+
+        let session = Session::create(&pool).await.unwrap();
+        (pool, session.id)
+    }
+
+    #[tokio::test]
+    async fn test_file_crud() {
+        let (pool, session_id) = setup_test_db().await;
+
+        let file = DiagramFile::create(&pool, &session_id, "test.mmd", Some("flowchart")).await.unwrap();
+        assert_eq!(file.name, "test.mmd");
+
+        let retrieved = DiagramFile::get_by_id(&pool, file.id, &session_id).await.unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().content, file.content);
+
+        let updated = retrieved.unwrap().update_content(&pool, "graph TD\nA --> B").await.unwrap();
+        assert_ne!(updated.content, file.content);
+
+        let list = DiagramFile::list_by_session(&pool, &session_id).await.unwrap();
+        assert_eq!(list.len(), 1);
+
+        let duplicated = updated.duplicate(&pool, Some("copy.mmd")).await.unwrap();
+        assert_eq!(duplicated.name, "copy.mmd");
+
+        updated.delete(&pool).await.unwrap();
+
+        let after_delete = DiagramFile::get_by_id(&pool, file.id, &session_id).await.unwrap();
+        assert!(after_delete.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,14 @@ pub mod serve;
 pub mod utils;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod codemap;
+#[cfg(feature = "server")]
+pub mod database;
+#[cfg(feature = "server")]
+pub mod session;
+#[cfg(feature = "server")]
+pub mod files;
+#[cfg(feature = "server")]
+pub mod export;
 
 pub use diagram::*;
 #[cfg(feature = "server")]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -9,22 +9,29 @@ use axum::http::StatusCode;
 use axum::http::{HeaderValue, header};
 use axum::response::IntoResponse;
 use axum::response::Response;
-use axum::routing::{delete, get, put};
+use axum::routing::{delete, get, put, post};
 use axum::{Json, Router};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, RwLock};
 use tower::ServiceExt;
 use tower::service_fn;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
+use http_body_util::BodyExt;
 
 use crate::codemap::CodeMapMapping;
-use crate::diagram::decode_image_dimensions;
+use crate::database::{Database, DatabaseConfig};
 use crate::*;
+use crate::utils::split_source_and_overrides;
+use crate::files::{DiagramFile, FileListItem};
+use crate::session::{Session, create_session_cookie};
+use crate::{LAYOUT_BLOCK_START, LAYOUT_BLOCK_END, NodeImage, decode_image_dimensions};
+use std::collections::HashMap;
 
 const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
 const MAX_IMAGE_REQUEST_BYTES: usize = (MAX_IMAGE_BYTES * 4) / 3 + 1 * 1024 * 1024;
@@ -33,9 +40,9 @@ const MAX_IMAGE_REQUEST_BYTES: usize = (MAX_IMAGE_BYTES * 4) / 3 + 1 * 1024 * 10
 #[derive(Debug, Clone, Parser)]
 #[command(name = "oxdraw serve", about = "Start the oxdraw web sync API server.")]
 pub struct ServeArgs {
-    /// Path to the diagram definition that should be served.
+    /// Path to the diagram definition that should be served (optional for multi-user mode).
     #[arg(short = 'i', long = "input")]
-    pub input: PathBuf,
+    pub input: Option<PathBuf>,
 
     /// Address to bind the HTTP server to.
     #[arg(long, default_value = "127.0.0.1")]
@@ -63,7 +70,8 @@ pub struct ServeArgs {
 }
 
 struct ServeState {
-    source_path: PathBuf,
+    database: Option<Database>,
+    source_path: Option<PathBuf>,
     background: String,
     overrides: RwLock<LayoutOverrides>,
     source_lock: Mutex<()>,
@@ -75,6 +83,9 @@ struct ServeState {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DiagramPayload {
+    id: i64,
+    name: String,
+    filename: String,
     source_path: String,
     background: String,
     auto_size: CanvasSize,
@@ -191,10 +202,15 @@ struct NodeImageUpdateRequest {
 }
 
 impl ServeState {
+    fn source_path_ref(&self) -> &PathBuf {
+        self.source_path.as_ref().unwrap()
+    }
+
     async fn read_diagram(&self) -> Result<(String, Diagram)> {
-        let contents = tokio::fs::read_to_string(&self.source_path)
+        let path = self.source_path_ref();
+        let contents = tokio::fs::read_to_string(path)
             .await
-            .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to read '{}'", path.display()))?;
         let (definition, _) = split_source_and_overrides(&contents)?;
         let diagram = Diagram::parse(&definition)?;
         Ok((contents, diagram))
@@ -354,14 +370,15 @@ impl ServeState {
 
     async fn rewrite_file_with_overrides(&self, overrides: &LayoutOverrides) -> Result<()> {
         let _guard = self.source_lock.lock().await;
-        let contents = tokio::fs::read_to_string(&self.source_path)
+        let path = self.source_path_ref();
+        let contents = tokio::fs::read_to_string(path)
             .await
-            .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to read '{}'", path.display()))?;
         let (definition, _) = split_source_and_overrides(&contents)?;
         let merged = merge_source_and_overrides(&definition, overrides)?;
-        tokio::fs::write(&self.source_path, merged.as_bytes())
+        tokio::fs::write(path, merged.as_bytes())
             .await
-            .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to write '{}'", path.display()))?;
         Ok(())
     }
 
@@ -372,18 +389,20 @@ impl ServeState {
     ) -> Result<()> {
         let merged = merge_source_and_overrides(definition, overrides)?;
         let _guard = self.source_lock.lock().await;
-        tokio::fs::write(&self.source_path, merged.as_bytes())
+        let path = self.source_path_ref();
+        tokio::fs::write(path, merged.as_bytes())
             .await
-            .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to write '{}'", path.display()))?;
         Ok(())
     }
 
     async fn remove_node(&self, node_id: &str) -> Result<bool> {
         let diagram = {
             let _guard = self.source_lock.lock().await;
-            let source = tokio::fs::read_to_string(&self.source_path)
+            let path = self.source_path_ref();
+            let source = tokio::fs::read_to_string(path)
                 .await
-                .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+                .with_context(|| format!("failed to read '{}'", path.display()))?;
             let mut diagram = Diagram::parse(&source)?;
             if diagram.nodes.len() == 1 && diagram.nodes.contains_key(node_id) {
                 bail!("diagram must contain at least one node");
@@ -392,9 +411,10 @@ impl ServeState {
                 return Ok(false);
             }
             let rewritten = diagram.to_definition();
-            tokio::fs::write(&self.source_path, rewritten.as_bytes())
+            let path = self.source_path_ref();
+            tokio::fs::write(path, rewritten.as_bytes())
                 .await
-                .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+                .with_context(|| format!("failed to write '{}'", path.display()))?;
             diagram
         };
 
@@ -405,17 +425,18 @@ impl ServeState {
     async fn remove_edge(&self, edge_id: &str) -> Result<bool> {
         let diagram = {
             let _guard = self.source_lock.lock().await;
-            let source = tokio::fs::read_to_string(&self.source_path)
+            let path = self.source_path_ref();
+            let source = tokio::fs::read_to_string(path)
                 .await
-                .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+                .with_context(|| format!("failed to read '{}'", path.display()))?;
             let mut diagram = Diagram::parse(&source)?;
             if !diagram.remove_edge_by_identifier(edge_id) {
                 return Ok(false);
             }
             let rewritten = diagram.to_definition();
-            tokio::fs::write(&self.source_path, rewritten.as_bytes())
+            tokio::fs::write(path, rewritten.as_bytes())
                 .await
-                .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+                .with_context(|| format!("failed to write '{}'", path.display()))?;
             diagram
         };
 
@@ -426,9 +447,10 @@ impl ServeState {
     async fn set_node_image(&self, node_id: &str, image: Option<NodeImage>) -> Result<()> {
         let overrides_snapshot = self.overrides.read().await.clone();
         let _guard = self.source_lock.lock().await;
-        let contents = tokio::fs::read_to_string(&self.source_path)
+        let path = self.source_path_ref();
+        let contents = tokio::fs::read_to_string(path)
             .await
-            .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to read '{}'", path.display()))?;
         let (definition, _) = split_source_and_overrides(&contents)?;
         let mut diagram = Diagram::parse(&definition)?;
         let Some(node) = diagram.nodes.get_mut(node_id) else {
@@ -437,18 +459,20 @@ impl ServeState {
         node.image = image;
         let rewritten = diagram.to_definition();
         let merged = merge_source_and_overrides(&rewritten, &overrides_snapshot)?;
-        tokio::fs::write(&self.source_path, merged.as_bytes())
+        let path = self.source_path_ref();
+        tokio::fs::write(path, merged.as_bytes())
             .await
-            .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to write '{}'", path.display()))?;
         Ok(())
     }
 
     async fn update_node_image_padding(&self, node_id: &str, padding: f32) -> Result<()> {
         let overrides_snapshot = self.overrides.read().await.clone();
         let _guard = self.source_lock.lock().await;
-        let contents = tokio::fs::read_to_string(&self.source_path)
+        let path = self.source_path_ref();
+        let contents = tokio::fs::read_to_string(path)
             .await
-            .with_context(|| format!("failed to read '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to read '{}'", path.display()))?;
         let (definition, _) = split_source_and_overrides(&contents)?;
         let mut diagram = Diagram::parse(&definition)?;
         let Some(node) = diagram.nodes.get_mut(node_id) else {
@@ -460,9 +484,9 @@ impl ServeState {
         image.padding = padding;
         let rewritten = diagram.to_definition();
         let merged = merge_source_and_overrides(&rewritten, &overrides_snapshot)?;
-        tokio::fs::write(&self.source_path, merged.as_bytes())
+        tokio::fs::write(path, merged.as_bytes())
             .await
-            .with_context(|| format!("failed to write '{}'", self.source_path.display()))?;
+            .with_context(|| format!("failed to write '{}'", path.display()))?;
         Ok(())
     }
 }
@@ -534,14 +558,31 @@ async fn open_in_editor(
 }
 
 pub async fn run_serve(args: ServeArgs, ui_root: Option<PathBuf>) -> Result<()> {
-    let initial_source = fs::read_to_string(&args.input)
-        .with_context(|| format!("failed to read '{}'", args.input.display()))?;
-    let (_, overrides) = split_source_and_overrides(&initial_source)?;
+    let database = if args.input.is_none() {
+        Some(Database::new(DatabaseConfig::default()).await?)
+    } else {
+        None
+    };
+
+    let initial_source = if let Some(ref input_path) = args.input {
+        let content = fs::read_to_string(input_path)
+            .with_context(|| format!("failed to read '{}'", input_path.display()))?;
+        let (_, overrides) = split_source_and_overrides(&content)?;
+        Some(content)
+    } else {
+        None
+    };
 
     let state = Arc::new(ServeState {
+        database,
         source_path: args.input.clone(),
         background: args.background_color.clone(),
-        overrides: RwLock::new(overrides),
+        overrides: RwLock::new(if let Some(ref source) = initial_source {
+            let (_, overrides) = split_source_and_overrides(source).unwrap_or_default();
+            overrides
+        } else {
+            LayoutOverrides::default()
+        }),
         source_lock: Mutex::new(()),
         code_map_root: args.code_map_root,
         code_map_mapping: args.code_map_mapping,
@@ -549,20 +590,36 @@ pub async fn run_serve(args: ServeArgs, ui_root: Option<PathBuf>) -> Result<()> 
     });
 
     let mut app = Router::new()
-        .route("/api/diagram", get(get_diagram))
-        .route("/api/diagram/svg", get(get_svg))
-        .route("/api/diagram/layout", put(put_layout))
-        .route("/api/diagram/style", put(put_style))
-        .route("/api/diagram/source", get(get_source).put(put_source))
-        .route("/api/diagram/nodes/:id/image", put(put_node_image))
-        .route("/api/diagram/nodes/:id", delete(delete_node))
-        .route("/api/diagram/edges/:id", delete(delete_edge))
+        .route("/api/sessions/current", get(get_current_session))
+        .route("/api/diagrams", get(list_diagrams).post(create_diagram))
+        .route("/api/diagrams/:id", get(get_diagram_by_id).delete(delete_diagram))
+        .route("/api/diagrams/:id/content", put(update_diagram_content))
+        .route("/api/diagrams/:id/name", put(update_diagram_name))
+        .route("/api/diagrams/:id/duplicate", post(duplicate_diagram))
+        .route("/api/diagrams/:id/svg", get(get_diagram_svg))
+        .route("/api/diagrams/:id/layout", put(put_layout_db))
+        .route("/api/diagrams/:id/style", put(put_style_db))
+        .route("/api/diagrams/:id/source", get(get_diagram_source).put(put_diagram_source))
+        .route("/api/diagrams/:id/nodes/:node_id/image", put(put_node_image_db))
+        .route("/api/diagrams/:id/nodes/:node_id", delete(delete_node_db))
+        .route("/api/diagrams/:id/edges/:edge_id", delete(delete_edge_db))
         .route("/api/codemap/mapping", get(get_codemap_mapping))
         .route("/api/codemap/status", get(get_codemap_status))
         .route("/api/codemap/file", get(get_codemap_file))
         .route("/api/codemap/open", axum::routing::post(open_in_editor))
-        .layer(DefaultBodyLimit::max(MAX_IMAGE_REQUEST_BYTES))
-        .with_state(state);
+        .layer(DefaultBodyLimit::max(MAX_IMAGE_REQUEST_BYTES));
+
+    if args.input.is_some() {
+        app = app
+            .route("/api/diagram", get(get_diagram))
+            .route("/api/diagram/svg", get(get_svg))
+            .route("/api/diagram/layout", put(put_layout))
+            .route("/api/diagram/style", put(put_style))
+            .route("/api/diagram/source", get(get_source).put(put_source))
+            .route("/api/diagram/nodes/:id/image", put(put_node_image))
+            .route("/api/diagram/nodes/:id", delete(delete_node))
+            .route("/api/diagram/edges/:id", delete(delete_edge));
+    }
 
     if let Some(root) = ui_root {
         let static_dir = ServeDir::new(root.clone())
@@ -574,7 +631,11 @@ pub async fn run_serve(args: ServeArgs, ui_root: Option<PathBuf>) -> Result<()> 
             let svc = dir_for_service.clone();
             async move {
                 match svc.oneshot(req).await {
-                    Ok(response) => Ok(response.map(axum::body::Body::new)),
+                    Ok(response) => {
+                        let (parts, body) = response.into_parts();
+                        let boxed = body.boxed_unsync();
+                        Ok(Response::from_parts(parts, axum::body::Body::new(boxed)))
+                    }
                     Err(error) => {
                         let message = format!("Static file error: {error}");
                         Ok((StatusCode::INTERNAL_SERVER_ERROR, message).into_response())
@@ -586,14 +647,21 @@ pub async fn run_serve(args: ServeArgs, ui_root: Option<PathBuf>) -> Result<()> 
         app = app.fallback_service(static_service);
     }
 
-    let app = app.layer(CorsLayer::permissive());
+    let app = app
+        .layer(CorsLayer::permissive())
+        .with_state(state.clone());
 
     let addr = format!("{}:{}", args.host, args.port);
     let listener = TcpListener::bind(&addr)
         .await
         .with_context(|| format!("failed to bind HTTP server to {addr}"))?;
 
-    println!("oxdraw server listening on http://{addr}");
+    let mode = if args.input.is_some() {
+        format!("file mode ({})", args.input.as_ref().unwrap().display())
+    } else {
+        "multi-user database mode".to_string()
+    };
+    println!("oxdraw server listening on http://{addr} ({mode})");
     println!("Press Ctrl+C to stop.");
 
     axum::serve(listener, app)
@@ -731,7 +799,10 @@ async fn get_diagram(
     }
 
     let payload = DiagramPayload {
-        source_path: state.source_path.display().to_string(),
+        id: 0,
+        name: String::new(),
+        filename: state.source_path.as_ref().and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned())).unwrap_or_default(),
+        source_path: state.source_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         background: state.background.clone(),
         auto_size: layout.auto_size,
         render_size: CanvasSize {
@@ -784,6 +855,166 @@ async fn put_style(
         .apply_style_update(update)
         .await
         .map_err(internal_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn put_layout_db(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(diagram_id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+    Json(update): Json<LayoutUpdate>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, diagram_id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, mut overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    for (id, value) in update.nodes {
+        match value {
+            Some(point) => {
+                overrides.nodes.insert(id, point);
+            }
+            None => {
+                overrides.nodes.remove(&id);
+            }
+        }
+    }
+
+    for (id, value) in update.edges {
+        match value {
+            Some(edge_override) if !edge_override.points.is_empty() => {
+                overrides.edges.insert(id, edge_override);
+            }
+            _ => {
+                overrides.edges.remove(&id);
+            }
+        }
+    }
+
+    let node_ids: HashSet<String> = diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+    overrides.prune(&node_ids, &edge_ids);
+
+    let new_definition = diagram.to_definition();
+    let merged = merge_source_and_overrides(&new_definition, &overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &merged).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn put_style_db(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(diagram_id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+    Json(update): Json<StyleUpdate>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, diagram_id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, mut overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    for (id, value) in update.node_styles {
+        match value {
+            Some(patch) => {
+                let mut current = overrides.node_styles.remove(&id).unwrap_or_default();
+                if let Some(fill) = patch.fill {
+                    current.fill = fill;
+                }
+                if let Some(stroke) = patch.stroke {
+                    current.stroke = stroke;
+                }
+                if let Some(text) = patch.text {
+                    current.text = text;
+                }
+                if let Some(label_fill) = patch.label_fill {
+                    current.label_fill = label_fill;
+                }
+                if let Some(image_fill) = patch.image_fill {
+                    current.image_fill = image_fill;
+                }
+                if current.is_empty() {
+                    overrides.node_styles.remove(&id);
+                } else {
+                    overrides.node_styles.insert(id, current);
+                }
+            }
+            None => {
+                overrides.node_styles.remove(&id);
+            }
+        }
+    }
+
+    for (id, value) in update.edge_styles {
+        match value {
+            Some(patch) => {
+                let mut current = overrides.edge_styles.remove(&id).unwrap_or_default();
+                if let Some(line) = patch.line {
+                    current.line = line;
+                }
+                if let Some(color) = patch.color {
+                    current.color = color;
+                }
+                if let Some(arrow) = patch.arrow {
+                    current.arrow = arrow;
+                }
+                if current.is_empty() {
+                    overrides.edge_styles.remove(&id);
+                } else {
+                    overrides.edge_styles.insert(id, current);
+                }
+            }
+            None => {
+                overrides.edge_styles.remove(&id);
+            }
+        }
+    }
+
+    let diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let node_ids: HashSet<String> = diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+    overrides.prune(&node_ids, &edge_ids);
+
+    let new_definition = diagram.to_definition();
+    let merged = merge_source_and_overrides(&new_definition, &overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &merged).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1036,4 +1267,697 @@ async fn get_codemap_file(
         .map_err(|e| (StatusCode::NOT_FOUND, format!("Failed to read file: {}", e)))?;
 
     Ok(content)
+}
+
+fn extract_session_id(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers.get(header::COOKIE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .find_map(|cookie| {
+            cookie.trim().split_once('=')
+                .filter(|(name, _)| *name == "oxdraw_session")
+                .map(|(_, value)| value.to_string())
+        })
+}
+
+async fn get_current_session(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<(StatusCode, impl IntoResponse), (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = if let Some(sid) = extract_session_id(&headers) {
+        sid
+    } else {
+        let session = Session::create(pool).await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        session.id
+    };
+
+    let session = Session::get_by_id(pool, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let session = match session {
+        Some(s) => {
+            s.touch(pool).await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            s
+        }
+        None => {
+            Session::create(pool).await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        }
+    };
+
+    let diagrams = DiagramFile::list_by_session(pool, &session.id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let current_diagram_id = if diagrams.is_empty() {
+        let new_diagram = DiagramFile::create(pool, &session.id, "New Diagram", None).await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        Some(new_diagram.id)
+    } else {
+        diagrams.first().map(|d| d.id)
+    };
+
+    let cookie = create_session_cookie(&session.id);
+    let json_value = json!({
+        "sessionId": session.id,
+        "diagrams": diagrams,
+        "currentDiagramId": current_diagram_id,
+    });
+
+    let mut response = Json(json_value).into_response();
+    response.headers_mut().insert(header::SET_COOKIE, HeaderValue::from_str(&cookie)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?);
+
+    Ok((StatusCode::OK, response))
+}
+
+async fn list_diagrams(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<Vec<FileListItem>>, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let session = Session::get_by_id(pool, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if session.is_none() {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid session".to_string()));
+    }
+
+    let diagrams = DiagramFile::list_by_session(pool, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(diagrams))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateDiagramRequest {
+    name: Option<String>,
+    template: Option<String>,
+}
+
+async fn create_diagram(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<CreateDiagramRequest>,
+) -> Result<Json<DiagramPayload>, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let session = Session::get_by_id(pool, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if session.is_none() {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid session".to_string()));
+    }
+
+    let name = req.name.unwrap_or_else(|| "New Diagram".to_string());
+    let template = req.template.as_deref();
+
+    let diagram_file = DiagramFile::create(pool, &session_id, &name, template).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    session.unwrap().touch(pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    convert_diagram_to_payload(pool, &state, diagram_file).await
+}
+
+async fn get_diagram_by_id(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<DiagramPayload>, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let session = Session::get_by_id(pool, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if session.is_none() {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid session".to_string()));
+    }
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    session.unwrap().touch(pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    convert_diagram_to_payload(pool, &state, diagram_file).await
+}
+
+async fn convert_diagram_to_payload(
+    _pool: &sqlx::SqlitePool,
+    state: &Arc<ServeState>,
+    diagram_file: DiagramFile,
+) -> Result<Json<DiagramPayload>, (StatusCode, String)> {
+    let (definition, overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let layout = diagram.layout(Some(&overrides))
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let geometry = align_geometry(
+        &layout.final_positions,
+        &layout.final_routes,
+        &diagram.edges,
+        &diagram.subgraphs,
+        &diagram.nodes,
+    )
+    .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut nodes = Vec::new();
+    for id in &diagram.order {
+        let node = diagram.nodes.get(id)
+            .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, format!("node '{id}' missing from diagram")))?;
+        let auto_position = layout.auto_positions.get(id)
+            .copied()
+            .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, format!("auto layout missing node '{id}'")))?;
+        let final_position = layout.final_positions.get(id)
+            .copied()
+            .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, format!("final layout missing node '{id}'")))?;
+        let override_position = overrides.nodes.get(id).copied();
+        let style = overrides.node_styles.get(id);
+        let fill_color = style.and_then(|s| s.fill.clone());
+        let stroke_color = style.and_then(|s| s.stroke.clone());
+        let text_color = style.and_then(|s| s.text.clone());
+        let label_fill_color = style.and_then(|s| s.label_fill.clone());
+        let image_fill_color = style.and_then(|s| s.image_fill.clone());
+        let image_payload = node.image.as_ref().map(|image| NodeImagePayload {
+            mime_type: image.mime_type.clone(),
+            data: BASE64_STANDARD.encode(&image.data),
+            width: image.width,
+            height: image.height,
+            padding: image.padding.max(0.0),
+        });
+        nodes.push(NodePayload {
+            id: id.clone(),
+            label: node.label.clone(),
+            shape: node.shape.as_str().to_string(),
+            auto_position,
+            rendered_position: final_position,
+            override_position,
+            fill_color,
+            stroke_color,
+            text_color,
+            label_fill_color,
+            image_fill_color,
+            membership: diagram.node_membership.get(id).cloned().unwrap_or_default(),
+            width: node.width,
+            height: node.height,
+            image: image_payload,
+        });
+    }
+
+    let mut edges = Vec::new();
+    for edge in &diagram.edges {
+        let identifier = edge_identifier(edge);
+        let auto_points = layout.auto_routes.get(&identifier)
+            .cloned()
+            .unwrap_or_default();
+        let final_points = layout.final_routes.get(&identifier)
+            .cloned()
+            .unwrap_or_default();
+        let manual_points = overrides.edges.get(&identifier)
+            .map(|edge_override| edge_override.points.clone());
+        let style = overrides.edge_styles.get(&identifier);
+        let line_kind = style.and_then(|s| s.line)
+            .unwrap_or(edge.kind)
+            .as_str()
+            .to_string();
+        let color = style.and_then(|s| s.color.clone());
+        let arrow_direction = style.and_then(|s| s.arrow)
+            .map(|direction| direction.as_str().to_string());
+
+        edges.push(EdgePayload {
+            id: identifier,
+            from: edge.from.clone(),
+            to: edge.to.clone(),
+            label: edge.label.clone(),
+            kind: line_kind,
+            auto_points,
+            rendered_points: final_points,
+            override_points: manual_points,
+            color,
+            arrow_direction,
+        });
+    }
+
+    let mut subgraphs = Vec::new();
+    for sg in &geometry.subgraphs {
+        subgraphs.push(SubgraphPayload {
+            id: sg.id.clone(),
+            label: sg.label.clone(),
+            x: sg.x,
+            y: sg.y,
+            width: sg.width,
+            height: sg.height,
+            label_x: sg.label_x,
+            label_y: sg.label_y,
+            depth: sg.depth,
+            order: sg.order,
+            parent_id: sg.parent_id.clone(),
+        });
+    }
+
+    let payload = DiagramPayload {
+        id: diagram_file.id,
+        name: diagram_file.name.clone(),
+        filename: diagram_file.filename.clone(),
+        source_path: diagram_file.filename.clone(),
+        background: state.background.clone(),
+        auto_size: layout.auto_size,
+        render_size: CanvasSize {
+            width: geometry.width,
+            height: geometry.height,
+        },
+        nodes,
+        edges,
+        subgraphs,
+        source: diagram_file.content.clone(),
+    };
+
+    Ok(Json(payload))
+}
+
+async fn get_diagram_svg(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+) -> Result<Response, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let override_ref = if overrides.is_empty() { None } else { Some(&overrides) };
+    let svg = diagram.render_svg(&state.background, override_ref)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut response = Response::new(svg.into());
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("image/svg+xml"),
+    );
+    Ok(response)
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateDiagramContentRequest {
+    content: String,
+}
+
+async fn update_diagram_content(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<UpdateDiagramContentRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    diagram_file.update_content(pool, &req.content).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateDiagramNameRequest {
+    name: String,
+}
+
+async fn update_diagram_name(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<UpdateDiagramNameRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let _diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let now = chrono::Utc::now();
+    let filename = if req.name.ends_with(".mmd") {
+        req.name.clone()
+    } else {
+        format!("{}.mmd", req.name)
+    };
+
+    sqlx::query("UPDATE diagrams SET name = ?, filename = ?, updated_at = ? WHERE id = ?")
+        .bind(&req.name)
+        .bind(&filename)
+        .bind(now.to_rfc3339())
+        .bind(id)
+        .execute(pool)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn duplicate_diagram(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<DiagramPayload>, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let new_diagram = diagram_file.duplicate(pool, None).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    convert_diagram_to_payload(pool, &state, new_diagram).await
+}
+
+async fn delete_diagram(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    diagram_file.delete(pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_diagram_source(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<SourcePayload>, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, _) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    Ok(Json(SourcePayload { source: definition }))
+}
+
+async fn put_diagram_source(
+    State(state): State<Arc<ServeState>>,
+    AxumPath(id): AxumPath<i64>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<SourceUpdateRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (_, mut existing_overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let new_diagram = Diagram::parse(&req.source)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid diagram source: {e}")))?;
+
+    let node_ids: HashSet<String> = new_diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = new_diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+    existing_overrides.prune(&node_ids, &edge_ids);
+
+    let content = merge_source_and_overrides(&req.source, &existing_overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &content).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn delete_node_db(
+    State(state): State<Arc<ServeState>>,
+    AxumPath((diagram_id, node_id)): AxumPath<(i64, String)>,
+    headers: axum::http::HeaderMap,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, diagram_id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    if diagram.nodes.len() == 1 && diagram.nodes.contains_key(&node_id) {
+        return Err((StatusCode::BAD_REQUEST, "diagram must contain at least one node".to_string()));
+    }
+
+    if !diagram.remove_node(&node_id) {
+        return Err((StatusCode::NOT_FOUND, format!("node '{node_id}' not found")));
+    }
+
+    let node_ids: HashSet<String> = diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+
+    let mut updated_overrides = overrides;
+    updated_overrides.prune(&node_ids, &edge_ids);
+
+    let new_definition = diagram.to_definition();
+    let merged = merge_source_and_overrides(&new_definition, &updated_overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &merged).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn delete_edge_db(
+    State(state): State<Arc<ServeState>>,
+    AxumPath((diagram_id, edge_id)): AxumPath<(i64, String)>,
+    headers: axum::http::HeaderMap,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, diagram_id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    if !diagram.remove_edge_by_identifier(&edge_id) {
+        return Err((StatusCode::NOT_FOUND, format!("edge '{edge_id}' not found")));
+    }
+
+    let node_ids: HashSet<String> = diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+
+    let mut updated_overrides = overrides;
+    updated_overrides.prune(&node_ids, &edge_ids);
+
+    let new_definition = diagram.to_definition();
+    let merged = merge_source_and_overrides(&new_definition, &updated_overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &merged).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn put_node_image_db(
+    State(state): State<Arc<ServeState>>,
+    AxumPath((diagram_id, node_id)): AxumPath<(i64, String)>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<NodeImageUpdateRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let pool = state.database.as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "Database mode not active".to_string()))?
+        .pool();
+
+    let session_id = extract_session_id(&headers)
+        .ok_or((StatusCode::UNAUTHORIZED, "No session".to_string()))?;
+
+    let diagram_file = DiagramFile::get_by_id(pool, diagram_id, &session_id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let diagram_file = diagram_file
+        .ok_or((StatusCode::NOT_FOUND, "Diagram not found".to_string()))?;
+
+    let (definition, mut overrides) = split_source_and_overrides(&diagram_file.content)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut diagram = Diagram::parse(&definition)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let node = diagram.nodes.get_mut(&node_id)
+        .ok_or((StatusCode::NOT_FOUND, format!("node '{node_id}' not found")))?;
+
+    let sanitized_padding = payload.padding.map(|value| {
+        if value.is_nan() || !value.is_finite() || value < 0.0 { 0.0 } else { value }
+    });
+
+    if payload.data.is_none() || payload.data.as_ref().map(|s| s.trim().is_empty()).unwrap_or(true) {
+        node.image = None;
+    } else {
+        let mime_type = payload.mime_type
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|v| !v.is_empty())
+            .ok_or((StatusCode::BAD_REQUEST, "mime_type is required".to_string()))?
+            .to_string();
+
+        let data_str = payload.data.as_ref().unwrap().trim();
+        let data = BASE64_STANDARD.decode(data_str.as_bytes())
+            .map_err(|err| (StatusCode::BAD_REQUEST, format!("invalid base64 payload: {err}")))?;
+
+        if data.len() > MAX_IMAGE_BYTES {
+            return Err((StatusCode::BAD_REQUEST, format!("image too large (max {} bytes)", MAX_IMAGE_BYTES)));
+        }
+
+        let (width, height) = decode_image_dimensions(&mime_type, &data)
+            .map_err(|err| (StatusCode::BAD_REQUEST, format!("unsupported image: {err}")))?;
+
+        node.image = Some(NodeImage {
+            mime_type,
+            data,
+            width,
+            height,
+            padding: sanitized_padding.unwrap_or(0.0),
+        });
+    }
+
+    let node_ids: HashSet<String> = diagram.nodes.keys().cloned().collect();
+    let edge_ids: HashSet<String> = diagram.edges.iter()
+        .map(|e| edge_identifier(e))
+        .collect();
+
+    overrides.prune(&node_ids, &edge_ids);
+
+    let new_definition = diagram.to_definition();
+    let merged = merge_source_and_overrides(&new_definition, &overrides)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    diagram_file.update_content(pool, &merged).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,126 @@
+use sqlx::SqlitePool;
+use anyhow::{Context, Result};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub last_activity_at: DateTime<Utc>,
+}
+
+impl Session {
+    pub async fn create(pool: &SqlitePool) -> Result<Self> {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        sqlx::query(
+            "INSERT INTO sessions (id, created_at, last_activity_at) VALUES (?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(now.to_rfc3339())
+        .bind(now.to_rfc3339())
+        .execute(pool)
+        .await
+        .context("Failed to create session")?;
+
+        Ok(Self {
+            id,
+            created_at: now,
+            last_activity_at: now,
+        })
+    }
+
+    pub async fn get_by_id(pool: &SqlitePool, id: &str) -> Result<Option<Self>> {
+        let row: Option<SessionRow> = sqlx::query_as(
+            "SELECT id, created_at, last_activity_at FROM sessions WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .context("Failed to get session")?;
+
+        Ok(row.map(|r| Self {
+            id: r.id,
+            created_at: r.created_at.parse().unwrap_or_else(|_| Utc::now()),
+            last_activity_at: r.last_activity_at.parse().unwrap_or_else(|_| Utc::now()),
+        }))
+    }
+
+    pub async fn touch(&self, pool: &SqlitePool) -> Result<()> {
+        let now = Utc::now();
+        sqlx::query(
+            "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        )
+        .bind(now.to_rfc3339())
+        .bind(&self.id)
+        .execute(pool)
+        .await
+        .context("Failed to update session activity")?;
+        Ok(())
+    }
+
+    pub async fn delete(&self, pool: &SqlitePool) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM sessions WHERE id = ?",
+        )
+        .bind(&self.id)
+        .execute(pool)
+        .await
+        .context("Failed to delete session")?;
+        Ok(())
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct SessionRow {
+    id: String,
+    created_at: String,
+    last_activity_at: String,
+}
+
+pub fn create_session_cookie(session_id: &str) -> String {
+    format!("oxdraw_session={}; Path=/; HttpOnly; SameSite=Lax; Max-Age=2592000", session_id)
+}
+
+pub fn clear_session_cookie() -> String {
+    "oxdraw_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use sqlx::SqlitePool;
+
+    #[tokio::test]
+    async fn test_session_lifecycle() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let pool = SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+            .await
+            .unwrap();
+
+        sqlx::query(r#"
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        "#).execute(&pool).await.unwrap();
+
+        let session = Session::create(&pool).await.unwrap();
+        assert!(!session.id.is_empty());
+
+        let retrieved = Session::get_by_id(&pool, &session.id).await.unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().id, session.id);
+
+        session.touch(&pool).await.unwrap();
+        session.delete(&pool).await.unwrap();
+
+        let after_delete = Session::get_by_id(&pool, &session.id).await.unwrap();
+        assert!(after_delete.is_none());
+    }
+}


### PR DESCRIPTION
## Disclaimer
This was entirely vibecoded with opencode using Opus 4.5 and MiniMax M2.1.
It works for me and might be a good starting point for selfhosting for multiple users via sessions. 
I did not use it locally and only tested the docker implementation. 

## Summary

Adds Docker Compose support for deploying oxdraw with persistent storage, enabling production-ready multi-user diagram editing sessions.

## Key Features
- **Docker Compose orchestration** - Frontend + Backend + nginx reverse proxy
- **Persistent SQLite storage** - Sessions and diagrams survive restarts
- **Auto-expiration** - Configurable TTL for session data (default 7 days)
- **Privacy-first** - No external dependencies, cookie-based sessions

## Technical Changes
- New modules: `database.rs`, `session.rs`, `files.rs`, `export.rs`
- Multi-stage Docker builds for both frontend and backend
- nginx proxy for API routing and static file serving
- Environment variables: `OXDRAW_MAX_FILES`, `OXDRAW_EXPIRATION_DAYS`, `OXDRAW_DB_PATH`

## Testing
- [ ] Run `docker compose up --build` successfully
- [ ] Create diagrams and verify persistence across restarts
- [ ] Test expiration logic
- [ ] Verify all existing tests pass (`cargo test`)

## Checklist
- [x] Code follows project style
- [x] Tests added for new functionality
- [x] Documentation updated (README)